### PR TITLE
Only include ELEMENT_NODEs in `this.images` array.

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -12,7 +12,7 @@ function Pack(container, options) {
   this.container = container
   this.isFragment = container instanceof DocumentFragment
   this.classes = !this.isFragment && classes(container)
-  this.images = slice(container.childNodes)
+  this.images = slice(container.childNodes).filter(isElement)
   this.top = options.top || 0
   this.width = options.width || container.clientWidth
   this.height = options.height || 120
@@ -46,7 +46,7 @@ Pack.prototype.append = function (images) {
   })
 
   this.totalheight = subpack.totalheight
-  this.images = this.images.concat(images)
+  this.images = this.images.concat(images.filter(isElement))
   this.mirror = this.mirror.concat(subpack.mirror)
 
   var container = this.container
@@ -185,4 +185,8 @@ function slice(x) {
 
 function add(a, b) {
   return a + b
+}
+
+function isElement(el) {
+  return el.nodeType && el.nodeType === Node.ELEMENT_NODE
 }


### PR DESCRIPTION
Other node types, such as `TEXT_NODE` or `DOCUMENT_FRAGMENT_NODE`, are missing a `.getAttribute()` method  and causing the script to throw an error if included in the array.

This is normally fine if you're creating the container element dynamically, but when you're just working with HTML there'll be a text node between each child. Was getting errors when trying it out with this markup:

``` html
<div data-grid style="position:relative">
  <div class="block" data-aspect-ratio="0.85"></div>
  <div class="block" data-aspect-ratio="0.45"></div>
  <div class="block" data-aspect-ratio="0.15"></div>
  <div class="block" data-aspect-ratio="0.55"></div>
</div>
```

These changes fixed the issue :)
