### PR TITLE
use width/heigh attribute or 1:1 if as fallback

### DIFF
--- a/dist/horizontal-grid-packing.js
+++ b/dist/horizontal-grid-packing.js
@@ -681,7 +681,8 @@ function calculateAspectRatio(image) {
     parseInt(image.getAttribute('data-width'), 10) /
     parseInt(image.getAttribute('data-height'), 10) ||
     parseInt(image.getAttribute('width'), 10) /
-    parseInt(image.getAttribute('height'), 10)
+    parseInt(image.getAttribute('height'), 10) ||
+    1 // last solution
   )
 }
 

--- a/dist/horizontal-grid-packing.js
+++ b/dist/horizontal-grid-packing.js
@@ -679,7 +679,9 @@ function calculateAspectRatio(image) {
   return image.aspectRatio || (image.aspectRatio =
     parseFloat(image.getAttribute('data-aspect-ratio')) ||
     parseInt(image.getAttribute('data-width'), 10) /
-    parseInt(image.getAttribute('data-height'), 10)
+    parseInt(image.getAttribute('data-height'), 10) ||
+    parseInt(image.getAttribute('width'), 10) /
+    parseInt(image.getAttribute('height'), 10)
   )
 }
 

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -173,7 +173,8 @@ function calculateAspectRatio(image) {
     parseInt(image.getAttribute('data-width'), 10) /
     parseInt(image.getAttribute('data-height'), 10)||
     parseInt(image.getAttribute('width'), 10) /
-    parseInt(image.getAttribute('height'), 10)
+    parseInt(image.getAttribute('height'), 10) ||
+    1
   )
 }
 

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -171,7 +171,9 @@ function calculateAspectRatio(image) {
   return image.aspectRatio || (image.aspectRatio =
     parseFloat(image.getAttribute('data-aspect-ratio')) ||
     parseInt(image.getAttribute('data-width'), 10) /
-    parseInt(image.getAttribute('data-height'), 10)
+    parseInt(image.getAttribute('data-height'), 10)||
+    parseInt(image.getAttribute('width'), 10) /
+    parseInt(image.getAttribute('height'), 10)
   )
 }
 


### PR DESCRIPTION
If one image has no ratio attributes the grid will fail completely.

My solution:
If data-\* attribiutes are missing (for example there is no way to add them), use width/height attributes.
In case of no ratio attributes use 1:1 as ratio.

So the grid will never fail.
